### PR TITLE
Refactor/reduce find type

### DIFF
--- a/src/atom.c
+++ b/src/atom.c
@@ -405,7 +405,7 @@ int atom_convert_type(int p1, int p2) {
     if (!t1->ptr_to && !t1->struct_of && !t1->enum_of && !t2->ptr_to && !t2->struct_of && !t2->enum_of) {
         return alloc_typed_pos_atom(TYPE_CONVERT, p2, t1);
     }
-    if (t1->ptr_to && t2->ptr_to && t2->ptr_to == find_type("void")) {
+    if (t1->ptr_to && t2->ptr_to && t2->ptr_to == type_void) {
         char buf[RCC_BUF_SIZE] = {0};
         dump_type(buf, t2);
         strcat(buf, " -> ");
@@ -432,7 +432,7 @@ int NOP_ATOM = 0;
 
 int alloc_nop_atom() {
     if (!NOP_ATOM) {
-        NOP_ATOM = alloc_typed_pos_atom(TYPE_NOP, 0, find_type("void"));
+        NOP_ATOM = alloc_typed_pos_atom(TYPE_NOP, 0, type_void);
     }
     return NOP_ATOM;
 }

--- a/src/atom.c
+++ b/src/atom.c
@@ -166,7 +166,7 @@ void build_int_atom(int pos, int type, int value) {
     atom_t *a = &program[pos];
     a->type = type;
     a->int_value = value;
-    a->t = find_type("int");
+    a->t = type_int;
 }
 
 void build_ptr_atom(int pos, int type, void *ptr) {
@@ -312,7 +312,7 @@ int alloc_index_atom(int base_pos, int index_pos) {
     index_pos = atom_to_rvalue(index_pos);
     int pos2 = alloc_typed_pos_atom(TYPE_ARRAY_INDEX, pos, t);
     alloc_typed_pos_atom(TYPE_ARG, index_pos, atom_type(index_pos));
-    alloc_typed_int_atom(TYPE_ARG, size, find_type("int"));
+    alloc_typed_int_atom(TYPE_ARG, size, type_int);
     //dump_atom_tree(pos2, 0);
     return pos2;
 }
@@ -325,7 +325,7 @@ int alloc_offset_atom(int base_pos, type_t *offset_t, int offset) {
         error("offset for non-struct atom #%d" , pos);
     }
  
-    int pos2 = alloc_binop_atom(TYPE_MEMBER_OFFSET, pos, alloc_typed_int_atom(TYPE_INTEGER, offset, find_type("int")));
+    int pos2 = alloc_binop_atom(TYPE_MEMBER_OFFSET, pos, alloc_typed_int_atom(TYPE_INTEGER, offset, type_int));
     atom_set_type(pos2, add_pointer_type(offset_t));
     return pos2;
 }
@@ -353,7 +353,7 @@ int calculate_if_constant_ops(int type, int lpos, int rpos) {
             case TYPE_EQ_LE: l_int = l_int <= r_int; break;
             case TYPE_EQ_LT: l_int = l_int < r_int; break;
         }
-        return alloc_typed_int_atom(TYPE_INTEGER, l_int, find_type("int"));
+        return alloc_typed_int_atom(TYPE_INTEGER, l_int, type_int);
     }
     return 0;
 }
@@ -370,7 +370,7 @@ int alloc_binop_atom(int type, int lpos, int rpos) {
         if (atom_type(rpos)->ptr_to != 0) {
             error("Cannot + or - between pointers");
         }
-        int size = alloc_typed_int_atom(TYPE_INTEGER, type_size(lpos_t->ptr_to), find_type("int"));
+        int size = alloc_typed_int_atom(TYPE_INTEGER, type_size(lpos_t->ptr_to), type_int);
         rpos = alloc_binop_atom(TYPE_MUL, rpos, size);
     }
 
@@ -384,7 +384,7 @@ int alloc_assign_op_atom(int type, int lval, int rval) {
     type_t *lval_t = atom_type(lval);
     type_t *rval_t = atom_type(rval);
     if (lval_t->ptr_to && !rval_t->ptr_to && (type == TYPE_ADD || type == TYPE_SUB)) {
-        rval = alloc_typed_pos_atom(TYPE_CONVERT, rval, find_type("int"));
+        rval = alloc_typed_pos_atom(TYPE_CONVERT, rval, type_int);
     } else {
         rval = atom_convert_type(lval_deref, atom_to_rvalue(rval));
     }
@@ -413,7 +413,7 @@ int atom_convert_type(int p1, int p2) {
         warning("implicit pointer conversion:%s", buf);
         return alloc_typed_pos_atom(TYPE_CONVERT, p2, t1);
     }
-    if (t1->enum_of && t2 == find_type("int")) {
+    if (t1->enum_of && t2 == type_int) {
         char buf[RCC_BUF_SIZE] = {0};
         dump_type(buf, t2);
         strcat(buf, " -> ");

--- a/src/emit.c
+++ b/src/emit.c
@@ -910,10 +910,10 @@ int out_global_constant_by_type(type_t *pt, int value) {
     } else if (pt == type_int) {
         out_int(".long\t", value, "");
         filled_size += 4;
-    } else if (pt == find_type("long")) {
+    } else if (pt == type_long) {
         out_int(".quad\t", value, "");
         filled_size += 4;
-    } else if (pt == add_pointer_type(find_type("char"))) {
+    } else if (pt == type_char_ptr) {
         out_int(".quad\t.G", value, "");
         filled_size += 8;
     }

--- a/src/emit.c
+++ b/src/emit.c
@@ -904,7 +904,7 @@ void compile_func(func *f) {
 
 int out_global_constant_by_type(type_t *pt, int value) {
     int filled_size = 0;
-    if (pt == find_type("char")) {
+    if (pt == type_char) {
         out_int(".byte\t", value, "");
         filled_size += 1;
     } else if (pt == type_int) {

--- a/src/emit.c
+++ b/src/emit.c
@@ -907,7 +907,7 @@ int out_global_constant_by_type(type_t *pt, int value) {
     if (pt == find_type("char")) {
         out_int(".byte\t", value, "");
         filled_size += 1;
-    } else if (pt == find_type("int")) {
+    } else if (pt == type_int) {
         out_int(".long\t", value, "");
         filled_size += 4;
     } else if (pt == find_type("long")) {

--- a/src/parse.c
+++ b/src/parse.c
@@ -51,7 +51,7 @@ int parse_string() {
     char *s;
     if (expect_string(&s)) {
         int index = add_global_string(s);
-        return alloc_typed_int_atom(TYPE_STRING, index, add_pointer_type(find_type("char")));
+        return alloc_typed_int_atom(TYPE_STRING, index, type_char_ptr);
     }
     return 0;
 }

--- a/src/parse.c
+++ b/src/parse.c
@@ -879,7 +879,7 @@ int parse_expr_statement() {
 
     pos = parse_expr_sequence();
     if (pos != 0 && expect(T_SEMICOLON)) {
-        return alloc_typed_pos_atom(TYPE_EXPR_STATEMENT, pos, find_type("void"));
+        return alloc_typed_pos_atom(TYPE_EXPR_STATEMENT, pos, type_void);
     }
     return 0;
 }
@@ -950,7 +950,7 @@ int parse_default_clause() {
         if (!expect(T_COLON)) {
             error("colon ':' is needed after 'default'");
         }
-        return alloc_typed_pos_atom(TYPE_DEFAULT, parse_block_or_statement_series(), find_type("void"));
+        return alloc_typed_pos_atom(TYPE_DEFAULT, parse_block_or_statement_series(), type_void);
     }
     return 0;
 }
@@ -1004,7 +1004,7 @@ int wrap_expr_sequence(int pos) {
     if (!pos) {
         return alloc_nop_atom();
     } else {
-        return  alloc_typed_pos_atom(TYPE_EXPR_STATEMENT, pos, find_type("void"));
+        return  alloc_typed_pos_atom(TYPE_EXPR_STATEMENT, pos, type_void);
     }
 }
 
@@ -1116,7 +1116,7 @@ int parse_print_statement() {
         if (!expect(T_LPAREN)) return 0;
         pos = parse_expr();
         if (pos != 0 && expect(T_RPAREN) && expect(T_SEMICOLON)) {
-            int oppos = alloc_typed_pos_atom(TYPE_PRINT, atom_to_rvalue(pos), find_type("void"));
+            int oppos = alloc_typed_pos_atom(TYPE_PRINT, atom_to_rvalue(pos), type_void);
             return oppos;
         }
     }
@@ -1126,7 +1126,7 @@ int parse_print_statement() {
 int parse_break_statement() {
     if (expect(T_BREAK)) {
         if (expect(T_SEMICOLON)) {
-            return alloc_typed_pos_atom(TYPE_BREAK, 0, find_type("void"));
+            return alloc_typed_pos_atom(TYPE_BREAK, 0, type_void);
         }
     }
     return 0;
@@ -1135,7 +1135,7 @@ int parse_break_statement() {
 int parse_continue_statement() {
     if (expect(T_CONTINUE)) {
         if (expect(T_SEMICOLON)) {
-            return alloc_typed_pos_atom(TYPE_CONTINUE, 0, find_type("void"));
+            return alloc_typed_pos_atom(TYPE_CONTINUE, 0, type_void);
         }
     }
     return 0;
@@ -1150,12 +1150,12 @@ int parse_return_statement() {
 
     pos = parse_expr_sequence();
     if (!pos) {
-        pos = alloc_typed_int_atom(TYPE_INTEGER, 0, find_type("void"));
+        pos = alloc_typed_int_atom(TYPE_INTEGER, 0, type_void);
     }
     if (!expect(T_SEMICOLON)) {
         error("invalid expr for return");
     }
-    return alloc_typed_pos_atom(TYPE_RETURN, pos, find_type("void"));
+    return alloc_typed_pos_atom(TYPE_RETURN, pos, type_void);
 }
 
 int parse_statement() {

--- a/src/parse.c
+++ b/src/parse.c
@@ -59,7 +59,7 @@ int parse_string() {
 int parse_int_literal() {
     int v=0;
     if(expect_int_unary(&v)) {
-        return alloc_typed_int_atom(TYPE_INTEGER, v, find_type("int"));
+        return alloc_typed_int_atom(TYPE_INTEGER, v, type_int);
     }
     return 0;
 }
@@ -97,7 +97,7 @@ int parse_var() {
     var_t *v = parse_var_name();
     if (v) {
         if (v->is_constant) {
-            return alloc_typed_int_atom(TYPE_INTEGER, v->int_value, find_type("int"));
+            return alloc_typed_int_atom(TYPE_INTEGER, v->int_value, type_int);
         } else {
             return alloc_var_atom(v);
         }
@@ -352,7 +352,7 @@ int parse_prefix_incdec() {
     if (!pos) {
         error("Invalid expr after '++'|'--'");
     }
-    return alloc_assign_op_atom(op_type, pos, alloc_typed_int_atom(TYPE_INTEGER, 1, find_type("int")));
+    return alloc_assign_op_atom(op_type, pos, alloc_typed_int_atom(TYPE_INTEGER, 1, type_int));
 }
 
 
@@ -394,7 +394,7 @@ int parse_signed() {
         if (!pos) {
             error("Invalid '-'");
         }
-        return alloc_binop_atom(TYPE_SUB, alloc_typed_int_atom(TYPE_INTEGER, 0, find_type("int")), atom_to_rvalue(pos));
+        return alloc_binop_atom(TYPE_SUB, alloc_typed_int_atom(TYPE_INTEGER, 0, type_int), atom_to_rvalue(pos));
     }
     return 0;
 }
@@ -413,7 +413,7 @@ int parse_sizeof() {
             if (!expect(T_RPAREN)) {
                 error("no () after sizeof");
             }
-            pos = alloc_typed_int_atom(TYPE_INTEGER, type_size(t), find_type("int"));
+            pos = alloc_typed_int_atom(TYPE_INTEGER, type_size(t), type_int);
         } else {
             set_token_pos(start_pos);
         }
@@ -425,7 +425,7 @@ int parse_sizeof() {
                 pos = atom_to_rvalue(pos);
             }
             int size = type_size(program[pos].t);
-            pos = alloc_typed_int_atom(TYPE_INTEGER, size, find_type("int"));
+            pos = alloc_typed_int_atom(TYPE_INTEGER, size, type_int);
         } else {
             error("invliad expr after sizeof");
         }
@@ -442,9 +442,9 @@ int parse_bitwise_not() {
         }
         pos = atom_to_rvalue(pos);
         if (program[pos].type == TYPE_INTEGER) {
-            return alloc_typed_int_atom(TYPE_INTEGER, ~(program[pos].int_value), find_type("int"));
+            return alloc_typed_int_atom(TYPE_INTEGER, ~(program[pos].int_value), type_int);
         }
-        return alloc_typed_pos_atom(TYPE_NEG, atom_to_rvalue(pos), find_type("int"));
+        return alloc_typed_pos_atom(TYPE_NEG, atom_to_rvalue(pos), type_int);
     }
     return 0;
 }
@@ -458,9 +458,9 @@ int parse_logical_not() {
         }
         pos = atom_to_rvalue(pos);
         if (program[pos].type == TYPE_INTEGER) {
-            return alloc_typed_int_atom(TYPE_INTEGER, !(program[pos].int_value), find_type("int"));
+            return alloc_typed_int_atom(TYPE_INTEGER, !(program[pos].int_value), type_int);
         }
-        return alloc_typed_pos_atom(TYPE_LOG_NOT, pos, find_type("int"));
+        return alloc_typed_pos_atom(TYPE_LOG_NOT, pos, type_int);
     }
     return 0;
 }
@@ -1036,7 +1036,7 @@ int parse_for_statement() {
     }
     cond_pos = parse_expr_sequence();
     if (!cond_pos) {
-        cond_pos = alloc_typed_int_atom(TYPE_INTEGER, 1, find_type("int")); // TRUE
+        cond_pos = alloc_typed_int_atom(TYPE_INTEGER, 1, type_int); // TRUE
     }   
     if (!expect(T_SEMICOLON)) {
         error("invalid end of the second part of 'for' conditions");
@@ -1551,7 +1551,7 @@ int parse_array_initializer(var_t *v, int array, int array_length) {
 
     for (index = 0; array_length == 0 || index < array_length; index++) {
         debug("parsing array initializer at index:%d", index);
-        int lval = alloc_index_atom(array, alloc_typed_int_atom(TYPE_INTEGER, index, find_type("int")));
+        int lval = alloc_index_atom(array, alloc_typed_int_atom(TYPE_INTEGER, index, type_int));
         int assign = parse_variable_initializer(lval);
         if (assign) {
             if (!pos) {

--- a/test/test.sh
+++ b/test/test.sh
@@ -53,10 +53,10 @@ function check_error {
 
 function run {
     local t=$1
-    echo "test: $t ------------------"
+    echo -n "test $t: "
     clean
     $COMPILE $t/test.c && check_result $t/expect.txt || check_error $t/expect-error.txt
-    echo "success"
+    echo "OK"
 }
 
 set -e
@@ -64,7 +64,7 @@ set -e
 CC=../bin/rcc
 GCC=gcc
 DEBUG_LOG=out/debug.log
-DEBUG_BIN=out/test.out
+DEBUG_BIN=out/t
 DEBUG_OBJ=out/test.o
 DEBUG_ASM=out/test.s
 


### PR DESCRIPTION
- substitute calling `find_type(...)` with `type_...` constants
- simplify test output